### PR TITLE
Clarify agent handoff and verification states

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -53,7 +53,7 @@ Write `plan.md` in this directory using `startup-template.md` as the structure. 
 
 Commit `plan.md` when done.
 
-## Phase 4: Execute
+## Phase 4: Execute Marketing-Only Deliverables
 
 For each selected strategy, execute the **Agent Tasks** listed in `playbook.md`. Commit outputs to subdirectories:
 
@@ -69,13 +69,44 @@ marketing/
 
 Work through one strategy at a time. After completing each strategy's tasks:
 1. Update the checklist in `plan.md`
-2. Commit the outputs
+2. Commit the outputs at a phase boundary
 3. Move to the next strategy
+
+## Phase 5: Product Implementation Handoff
+
+If the next highest-value work requires changes outside `marketing/` — for example:
+
+- publishing SEO or AEO pages in the real app
+- wiring homepage links
+- implementing share flows
+- adding analytics events
+- submitting sitemaps or verifying live behavior
+
+do **not** keep generating more low-signal docs inside `marketing/`.
+
+Instead, produce a concise implementation handoff that includes:
+
+- what should be built in the product
+- which files, routes, or surfaces are affected
+- what can be verified locally vs what requires live deployment
+- the recommended execution order
+
+## Phase 6: Live Rollout and Verification
+
+If the user explicitly wants deployment or verification work, track these separately:
+
+- **Implemented locally** — files, specs, or code created in the repo
+- **Deployed live** — changes are actually live on the product URL
+- **Externally verified** — live URLs, Search Console, analytics, or other external systems were checked directly
+
+Do not mark anything as published, submitted, indexed, deployed, or verified unless that exact action was completed and checked.
 
 ## Rules
 
 - Never leave `{{VARIABLES}}` or placeholder text in outputs — everything must be specific to this product
 - Content must sound human — add specifics, examples, opinions. Flag anything that feels like slop.
 - If the codebase doesn't give you enough info to execute a task, note what's missing in `plan.md` under Notes and move on
-- Commit frequently with descriptive messages
-- Do not modify any files outside the `marketing/` directory
+- Prefer phase-boundary commits over frequent partial commits
+- If remaining work requires app-code changes, deployment access, or external systems, stop generating new collateral and produce a handoff instead
+- Prefer quality over breadth: ship a few strong artifacts rather than many weak ones
+- Do not modify any files outside the `marketing/` directory unless the user explicitly asks for implementation outside it

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The agent will:
 2. **Select** — pick the best 2-3 strategies from the playbook
 3. **Plan** — generate a tailored `plan.md` with real tasks and metrics
 4. **Execute** — produce marketing artifacts (content, SEO pages, outreach, etc.)
+5. **Handoff** — when the next step requires app-code changes or live rollout, generate an implementation-ready handoff instead of endlessly expanding docs
 
 No manual setup. No forms to fill in. The protocol bootstraps from your code.
 
@@ -53,6 +54,20 @@ marketing/
   aeo/            — FAQ content, schema markup
   artifacts/      — viral artifact designs, share copy
 ```
+
+## Important Boundary
+
+By default, this playbook is designed to generate and organize marketing work inside `marketing/`.
+
+If the next valuable step requires:
+
+- publishing pages in the real app
+- wiring homepage or product UX changes
+- implementing share flows
+- adding analytics
+- submitting sitemaps or checking live behavior
+
+the agent should switch from content generation to an **implementation handoff** unless the user explicitly asks it to modify the product code.
 
 ## Source
 


### PR DESCRIPTION
This PR improves the agent protocol based on real-world use of the playbook on a live startup repo.

Main goals:
- clarify the boundary between marketing-only work and product implementation work
- prevent agents from overstating local work as live completion
- reduce diminishing-return doc generation once the highest-value marketing work is done

## Changes

- Add an explicit handoff phase to AGENT.md
- Add local vs live verification language
- Add a stop condition for remaining work that requires app-code changes or external systems
- Change commit guidance to phase-boundary commits
- Clarify the README so users know the playbook produces a marketing package and implementation handoff, not necessarily live product changes

## Why

In practice, the current protocol is very good at:
- discovering the product
- selecting strategies
- producing a strong marketing spec bundle

The main friction starts after that:
- agents keep generating more docs inside marketing/
- remaining work often actually requires product code, deployment, or external tools
- status can drift because done locally gets treated like done live

These changes make the protocol more reliable in agentic workflows without changing the core value proposition.
