### PR TITLE
Add minimal .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# OS
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Editors
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Logs
+*.log
+
+# Local tool artifacts
+.codex
+nanobanana-output/


### PR DESCRIPTION
## Summary

Adds a minimal .gitignore to prevent accidental junk commits. Flagged during PR #9 review: the repo currently has no .gitignore, and there are already two untracked local artifacts sitting in working dirs (.codex and nanobanana-output/) that are easy to commit by accident.

## Scope

Intentionally minimal — this repo is markdown-only, so no language-specific ignores (Python, Node, Rust, etc.) are needed. Covers:

- OS junk (.DS_Store, Thumbs.db, desktop.ini)
- Editor swap/config (*.swp, *.swo, *~, .idea/, .vscode/)
- Env files (.env, .env.local, .env.*.local)
- Logs (*.log)
- The two known local tool artifacts (.codex, nanobanana-output/)

## Test plan

- [ ] \`git check-ignore .codex\` returns a match
- [ ] \`git check-ignore nanobanana-output/\` returns a match
- [ ] \`git status\` on a clean checkout shows nothing untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)